### PR TITLE
Adds path variable to the AWS request url

### DIFF
--- a/AWSRequestV4.class.nut
+++ b/AWSRequestV4.class.nut
@@ -20,7 +20,7 @@ class AWSRequestV4 {
         _region = region;
         _accessKeyId = accessKeyId;
         _secretAccessKey = secretAccessKey;
-        _serviceUrl = format("https://%s.%s.amazonaws.com/", service, region);
+        _serviceUrl = format("https://%s.%s.amazonaws.com", service, region);
         _serviceHost = format("%s.%s.amazonaws.com", service, region);
     }
 
@@ -40,8 +40,9 @@ class AWSRequestV4 {
 
         // This header is added *after* the request is signed
         headers["X-Amz-Date"] <- _dateTime;
+        local url = _serviceUrl + path
 
-        http.request(method, _serviceUrl, headers, body).sendasync(cb);
+        http.request(method, url, headers, body).sendasync(callback);
     }
 
     // function get(path, headers, cb) {


### PR DESCRIPTION
Hi Electric Imp Team,

Was working to call AWS Lambda using the AWSRequestV4 library (perhaps can share example code for that in the near future), but ran into an issue with the "path" variable not being used. Also a missing "cb" variable.

Here's what fixed it for me. Comments welcome. I tried it briefly with the Kinesis Firehose library/example code, and don't think it breaks anything, but more testing would be wise.

Thoughts?

Steven
